### PR TITLE
Added "magic" to the list of HoldTypes

### DIFF
--- a/lua/weapons/swep_construction_kit/shared.lua
+++ b/lua/weapons/swep_construction_kit/shared.lua
@@ -52,7 +52,7 @@ SWEP.HoldType = "pistol"
 SWEP.HoldTypes = { "normal", "melee", "melee2", "fist", 
 "knife", "smg", "ar2", "pistol", "revolver", "rpg", "physgun", 
 "grenade", "shotgun", "crossbow", "slam", "duel", "passive",
-"camera" }
+"camera", "magic" }
 
 SWEP.Spawnable			= true
 SWEP.AdminSpawnable		= true


### PR DESCRIPTION
The magic hold type was missing from the holdtype list of the swep, http://wiki.garrysmod.com/page/Hold_Types
